### PR TITLE
Don't publish default initial pose to /initialpose

### DIFF
--- a/include/amcl/node/node.h
+++ b/include/amcl/node/node.h
@@ -158,6 +158,7 @@ private:
   ros::Publisher alt_particlecloud_pub_;
   ros::Publisher map_odom_transform_pub_;
   bool publish_initial_pose_at_startup_;
+  bool initial_pose_loaded_;
   ros::Publisher initial_pose_pub_;
   ros::Subscriber initial_pose_sub_;
   ros::ServiceServer global_loc_srv_;


### PR DESCRIPTION
Badger-amcl is now responsible for loaded saved poses and publishing to /initialpose.
It shouldn't publish to /initialpose if it is not able to load a saved pose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/5)
<!-- Reviewable:end -->
