### PR TITLE
Preventing race between pf and receiving a scan

### DIFF
--- a/src/amcl/node/node_2d.cpp
+++ b/src/amcl/node/node_2d.cpp
@@ -397,6 +397,12 @@ bool Node2D::isMapInitialized()
 {
   if (map_ == NULL)
   {
+    ROS_DEBUG("Map is null");
+    return false;
+  }
+  if (pf_ == NULL)
+  {
+    ROS_DEBUG("PF is null");
     return false;
   }
   if (not map_->isDistancesLUTCreated())

--- a/src/amcl/node/node_3d.cpp
+++ b/src/amcl/node/node_3d.cpp
@@ -375,6 +375,11 @@ bool Node3D::isMapInitialized()
     ROS_DEBUG("Map is null");
     return false;
   }
+  if (pf_ == NULL)
+  {
+    ROS_DEBUG("PF is null");
+    return false;
+  }
   if (not map_->isDistancesLUTCreated())
   {
     ROS_DEBUG("Distances not yet created");


### PR DESCRIPTION
There is a race between passing the particle filter from
node to node_2/3d and a scan being received. If the scan
is received first then ignore the scan.

BF: ROS-664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/18)
<!-- Reviewable:end -->
