### PR TITLE
Adding threshold to global localization convergence

### DIFF
--- a/include/amcl/node/node.h
+++ b/include/amcl/node/node.h
@@ -198,6 +198,7 @@ private:
   double d_thresh_, a_thresh_;
   PFResampleModelType resample_model_type_;
   int min_particles_, max_particles_;
+  double global_localization_convergence_threshold_;
   std::shared_ptr<PoseHypothesis> initial_pose_hyp_;
   double init_pose_[3];
   double init_cov_[3];

--- a/include/amcl/pf/particle_filter.h
+++ b/include/amcl/pf/particle_filter.h
@@ -94,7 +94,7 @@ class ParticleFilter
 public:
   // Create a new filter
   ParticleFilter(int min_samples, int max_samples, double alpha_slow, double alpha_fast,
-                 std::function<Eigen::Vector3d()> random_pose_fn);
+                 double global_localization_convergence_threshold, std::function<Eigen::Vector3d()> random_pose_fn);
 
   // Set the resample model
   void setResampleModel(PFResampleModelType resample_model);
@@ -166,6 +166,8 @@ private:
   std::function<Eigen::Vector3d()> random_pose_fn_;
 
   double dist_threshold_;  // distance threshold in each axis over which the pf is considered to not be converged
+
+  double global_localization_convergence_threshold_;
 
   // Population size parameters
   double pop_err_, pop_z_;

--- a/src/amcl/node/node.cpp
+++ b/src/amcl/node/node.cpp
@@ -76,6 +76,7 @@ Node::Node()
   private_nh_.param("odom_alpha3", alpha3_, 0.2);
   private_nh_.param("odom_alpha4", alpha4_, 0.2);
   private_nh_.param("odom_alpha5", alpha5_, 0.2);
+  private_nh_.param("global_localization_convergence_threshold", global_localization_convergence_threshold_, 95.0);
 
   private_nh_.param("save_pose", save_pose_, false);
   const std::string default_filepath = "badger_amcl_saved_pose.yaml";
@@ -260,7 +261,7 @@ void Node::reconfigureCB(AMCLConfig& config, uint32_t level)
 
   uniform_pose_generator_fn_ = std::bind(&Node::uniformPoseGenerator, this);
   pf_ = std::make_shared<ParticleFilter>(min_particles_, max_particles_, alpha_slow_, alpha_fast_,
-                                         uniform_pose_generator_fn_);
+                                         global_localization_convergence_threshold_, uniform_pose_generator_fn_);
   pf_err_ = config.kld_err;
   pf_z_ = config.kld_z;
   pf_->setPopulationSizeParameters(pf_err_, pf_z_);
@@ -638,7 +639,7 @@ void Node::initFromNewMap(std::shared_ptr<Map> new_map, bool use_initial_pose)
   // Create the particle filter
   uniform_pose_generator_fn_ = std::bind(&Node::uniformPoseGenerator, this);
   pf_ = std::make_shared<ParticleFilter>(min_particles_, max_particles_, alpha_slow_, alpha_fast_,
-                                         uniform_pose_generator_fn_);
+                                         global_localization_convergence_threshold_,uniform_pose_generator_fn_);
   pf_->setPopulationSizeParameters(pf_err_, pf_z_);
   pf_->setResampleModel(resample_model_type_);
 

--- a/src/amcl/node/node_2d.cpp
+++ b/src/amcl/node/node_2d.cpp
@@ -673,6 +673,7 @@ void Node2D::globalLocalizationCallback()
                      global_localization_non_free_space_factor_,
                      non_free_space_radius_);
   }
+  global_localization_active_ = true;
 }
 
 }  // namespace amcl

--- a/src/amcl/node/node_3d.cpp
+++ b/src/amcl/node/node_3d.cpp
@@ -482,9 +482,12 @@ void Node3D::updateLatestScanData(const pcl::PointCloud<pcl::PointXYZ>::Ptr poin
 void Node3D::resampleParticles()
 {
   pf_->updateResample();
-  if (pf_->isConverged() && global_localization_active_)
+  bool is_converged = pf_->isConverged();
+  ROS_INFO_STREAM("Localization Converged: " << is_converged
+                  << ", Localization Active: " << global_localization_active_);
+  if (is_converged && global_localization_active_)
   {
-    ROS_INFO("Global localization converged!");
+    ROS_INFO("Global localization convergeed!");
     global_localization_active_ = false;
   }
 }
@@ -593,6 +596,7 @@ void Node3D::globalLocalizationCallback()
                      global_localization_non_free_space_factor_,
                      non_free_space_radius_);
   }
+  global_localization_active_ = true;
 }
 
 }  // namespace amcl


### PR DESCRIPTION
Added Succes and Failure percentage logs
Adding convergence test after weighing particles
Changing success threshold to a node

Creating an adjustable node that allows us the set a threshold that we use to define and determine when the particles have converged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/21)
<!-- Reviewable:end -->
