### PR TITLE
Start amcl using salt

### DIFF
--- a/salt_srv/salt/truck/config/amcl/amcl.sls
+++ b/salt_srv/salt/truck/config/amcl/amcl.sls
@@ -1,0 +1,2 @@
+{% from 'badger-lib.sls' import enable_service with context %}
+{{ enable_service('toetic', 'amcl') }}


### PR DESCRIPTION
To avoid waiting for the snap.toetic.target to start amcl,
use salt to start it directly.  This avoids delays in the boot
process.

ROS-956: Occasionally amcl takes several minutes longer to launch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/22)
<!-- Reviewable:end -->
