### PR TITLE
save pose to disk on timer

### DIFF
--- a/cfg/AMCL.cfg
+++ b/cfg/AMCL.cfg
@@ -46,7 +46,6 @@ gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via
 gen.add("tf_reverse", bool_t, 0, "When set to true, reverse published TF.", False)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
 gen.add("transform_publish_rate", double_t, 0, "Rate (Hz) at which to publish the transform between map and odom to tf.", 50.0, 0.1, 100.0)
-gen.add("save_pose_to_server_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. 0.0 to disable.", 2.0, 0, 10)
 gen.add("save_pose_to_file_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to file. This saved pose will be used on subsequent runs to initialize the filter if the param server does not have the parameters stored. 0.0 to disable.", 0.1, 0.0, 10.0)
 
 gen.add("use_map_topic", bool_t, 0, "When set to true, AMCL will subscribe to the map topic rather than making a service call to receive its map.", False)

--- a/include/amcl/node/node.h
+++ b/include/amcl/node/node.h
@@ -186,7 +186,6 @@ private:
   std::string global_alt_frame_id_;
 
   ros::Duration transform_publish_period_;
-  ros::Time save_pose_to_file_last_time_;
   ros::Duration save_pose_to_file_period_;
   bool save_pose_;
   std::string saved_pose_filepath_;
@@ -215,6 +214,7 @@ private:
   ros::AsyncSpinner publish_transform_spinner_;
   ros::NodeHandle publish_transform_nh_;
   ros::Timer publish_transform_timer_;
+  ros::Timer save_pose_to_file_timer_;
 
   bool global_localization_active_;
   double global_localization_alpha_slow_, global_localization_alpha_fast_;

--- a/src/amcl/node/node_2d.cpp
+++ b/src/amcl/node/node_2d.cpp
@@ -356,8 +356,6 @@ void Node2D::scanReceived(const sensor_msgs::LaserScanConstPtr& planar_scan)
       success = success and updateScanner(planar_scan, scanner_index, &resampled);
     if(force_publication or resampled)
       success = success and resamplePose(stamp);
-    if(success)
-      node_->attemptSavePose(false);
   }
 }
 

--- a/src/amcl/node/node_3d.cpp
+++ b/src/amcl/node/node_3d.cpp
@@ -336,10 +336,6 @@ void Node3D::scanReceived(const sensor_msgs::PointCloud2ConstPtr& point_cloud_sc
       updateScanner(point_cloud_scan, scanner_index, &resampled);
     if(force_publication or resampled)
       success = success and resamplePose(stamp);
-    if(success)
-    {
-      node_->attemptSavePose(false);
-    }
   }
 }
 


### PR DESCRIPTION
    Save the pose to disk on its own timer. IO can be slow and block the
    localization process an indefinite amount of time. To prevent IO from
    slowing down localization, save the pose on its own timer. This works
    because badger_amcl runs all callbacks in a a multi-threaded spinner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/23)
<!-- Reviewable:end -->
