### PR TITLE
Fix race in CMakeLists due to missing ordering constraint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(badger_amcl
     src/amcl/node/node_3d.cpp
     src/amcl/node/node.cpp
 )
+add_dependencies(badger_amcl ${PROJECT_NAME}_gencfg)
 
 target_link_libraries(badger_amcl
     ${OCTOMAP_LIBRARIES}


### PR DESCRIPTION
The dyncfg generation must happen before the library is built, but this
wasn't declared.  Found during Yocto port but could also break a
catkin/snap build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/24)
<!-- Reviewable:end -->
