### PR TITLE
Fix broken badger_amcl test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,11 @@ target_link_libraries(
 )
 
 if(CATKIN_ENABLE_TESTING)
-    catkin_add_gtest(TestBadgerAmcl test/test_badger_amcl.cpp)
-    target_link_libraries(TestBadgerAmcl badger_amcl ${catkin_LIBRARIES})
+    find_package(rostest REQUIRED)
+    add_rostest_gtest(badger-amcl-test
+                      test/badger_amcl.test
+                      test/test_badger_amcl.cpp)
+    target_link_libraries(badger-amcl-test badger_amcl ${catkin_LIBRARIES})
 endif()
 
 install( TARGETS

--- a/test/badger_amcl.test
+++ b/test/badger_amcl.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="badger_amcl" pkg="badger_amcl" type="badger-amcl-test"/>
+</launch>


### PR DESCRIPTION
Replace catkin_add_gtest with add_rostest_gtest so the gtest can run with roscore

Adding test file for badger_amcl

ROS-1011

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/badger_amcl/25)
<!-- Reviewable:end -->
