### PR TITLE
Get tests running on yocto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,13 @@ target_link_libraries(
 )
 
 if(CATKIN_ENABLE_TESTING)
-    find_package(rostest REQUIRED)
-    add_rostest_gtest(badger-amcl-test
-                      test/badger_amcl.test
-                      test/test_badger_amcl.cpp)
+    find_package(badger_test_lib)
+    badger_add_rostest_gtest(badger-amcl-test
+                             test/badger_amcl.test
+                             test/test_badger_amcl.cpp)
     target_link_libraries(badger-amcl-test badger_amcl ${catkin_LIBRARIES})
+
+    badger_generate_test_script()
 endif()
 
 install( TARGETS

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
     <license>LGPL</license>
 
     <buildtool_depend>catkin</buildtool_depend>
+    <build_depend>badger_test_lib</build_depend>
 
     <depend>dynamic_reconfigure</depend>
     <depend>nav_msgs</depend>


### PR DESCRIPTION
Add ability for rostests and nosetests to run
on a yocto build.

ROS-1299

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/badger_amcl/26)
<!-- Reviewable:end -->
