### PR TITLE
publish initial pose as TF when no sensor data

### DIFF
--- a/include/amcl/node/node.h
+++ b/include/amcl/node/node.h
@@ -87,8 +87,7 @@ public:
   std::string getBaseFrameId();
   std::shared_ptr<ParticleFilter> getPfPtr();
   void publishParticleCloud();
-  void updatePose(const Eigen::Vector3d& max_hyp_mean, const ros::Time& stamp);
-  void updateOdomToMapTransform(const tf2::Transform& odom_to_map);
+  bool updatePose(const Eigen::Vector3d& max_pose, const ros::Time& stamp);
   bool updatePf(const ros::Time& t, std::vector<bool>& scanners_update, int scanner_index,
                 int* resample_count, bool* force_publication, bool* force_update);
   void setPfDecayRateNormal();
@@ -207,7 +206,7 @@ private:
 
   bool first_reconfigure_call_;
   std::mutex configuration_mutex_;
-  std::mutex tf_mutex_;
+  std::recursive_mutex tf_mutex_;
   std::mutex latest_pose_mutex_;
   dynamic_reconfigure::Server<AMCLConfig> dsrv_;
   AMCLConfig default_config_;

--- a/src/amcl/node/node_2d.cpp
+++ b/src/amcl/node/node_2d.cpp
@@ -576,7 +576,7 @@ bool Node2D::resamplePose(const ros::Time& stamp)
   getMaxWeightPose(&max_weight, &max_pose);
   bool success = true;
   if(max_weight > 0.0)
-    success = updatePose(max_pose, stamp);
+    success = node_->updatePose(max_pose, stamp);
   else
   {
     ROS_ERROR("No pose!");
@@ -614,42 +614,6 @@ void Node2D::getMaxWeightPose(double* max_weight_rtn, Eigen::Vector3d* max_pose)
   }
   *max_weight_rtn = max_weight;
   *max_pose = hyps[max_weight_hyp].mean;
-}
-
-bool Node2D::updatePose(const Eigen::Vector3d& max_pose, const ros::Time& stamp)
-{
-  ROS_DEBUG("Max weight pose: %.3f %.3f %.3f", max_pose[0], max_pose[1], max_pose[2]);
-  node_->updatePose(max_pose, stamp);
-  bool success = true;
-  // subtracting base to odom from map to base and send map to odom instead
-  tf2::Quaternion q;
-  q.setRPY(0.0, 0.0, max_pose[2]);
-  tf2::Transform base_to_map_tf(q, tf2::Vector3(max_pose[0], max_pose[1], 0.0));
-  base_to_map_tf = base_to_map_tf.inverse();
-  std::string odom_frame_id = node_->getOdomFrameId();
-  std::string base_frame_id = node_->getBaseFrameId();
-  geometry_msgs::Pose base_to_map_msg, odom_to_map_msg;
-  base_to_map_msg.position = tf2::toMsg(base_to_map_tf.getOrigin(), base_to_map_msg.position);
-  base_to_map_msg.orientation = tf2::toMsg(base_to_map_tf.getRotation());
-  try
-  {
-    geometry_msgs::TransformStamped t;
-    t = tf_buffer_.lookupTransform(odom_frame_id, base_frame_id, stamp, ros::Duration(1.0));
-    tf2::doTransform(base_to_map_msg, odom_to_map_msg, t);
-  }
-  catch (tf2::TransformException)
-  {
-    ROS_DEBUG("Failed to subtract base to odom transform");
-    success = false;
-  }
-
-  if(success)
-  {
-    tf2::Transform odom_to_map_transform;
-    tf2::fromMsg(odom_to_map_msg, odom_to_map_transform);
-    node_->updateOdomToMapTransform(odom_to_map_transform);
-  }
-  return success;
 }
 
 void Node2D::checkScanReceived(const ros::TimerEvent& event)


### PR DESCRIPTION
If no sensor data is received, but there is a map and odometry, go ahead and begin publishing the map to odom transform using the initial pose. Too many other systems depend on the map to odom transform being present that not having one floods the system log with all kinds of transform timeouts, muddying the true issue (that no sensor data was being received). There may even be times when the sensors are intentionally off when power is being saved, and if somehow AMCL gets restarted in that state, it should continue to publish the initial pose as the current map to odom TF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/badger_amcl/29)
<!-- Reviewable:end -->
