### PR TITLE
Use fmod for yaw normalization in PFKDTree::getKey

### DIFF
--- a/src/amcl/node/node.cpp
+++ b/src/amcl/node/node.cpp
@@ -442,6 +442,14 @@ bool Node::loadPoseFromFile()
     xx = config["pose"]["covariance"][COVARIANCE_XX].as<double>();
     yy = config["pose"]["covariance"][COVARIANCE_YY].as<double>();
     aa = config["pose"]["covariance"][COVARIANCE_AA].as<double>();
+    // The yaw normalization while loop in pf_kdtree runs aa^0.5 / (2*pi) iterations per
+    // particle; fmod becomes cheaper at ~20 iterations (40*pi), so clamp here to avoid
+    // near-infinite loops during particle initialization.
+    if (aa > (40 * M_PI) * (40 * M_PI))
+    {
+      ROS_WARN("Saved pose yaw covariance (%f) is unreasonably large, using default.", aa);
+      aa = default_cov_vals_[COVARIANCE_AA];
+    }
     if(config["header"]["on_exit"])
       on_exit = config["header"]["on_exit"].as<bool>();
     else


### PR DESCRIPTION
The previous loop continued for nearly eternity when a loop is not necessary in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/badger_amcl/37)
<!-- Reviewable:end -->
